### PR TITLE
tweaking setup to support differences (and a bug) with google SDK, linux and first setup

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -38,11 +38,12 @@ module.exports = function(grunt) {
 
     shell: {
       local: {
-        command: 'dev_appserver.py --skip_sdk_update_check --host localhost --port 8081 --admin_host localhost .',
+        //just for TEST_CONFIG.  if not, then -A needs to depend on appName
+        command: 'dev_appserver.py -A whysaurustest --skip_sdk_update_check --host localhost --port 8081 --admin_host localhost .',
         options: {
           async: false,
         },        
-      }      
+      }
     },
     gae: {
         options: {

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Basic Setup Instructions:
 1. Clone
 2. Get constants.py from a collaborator and put it in this directory
 3. Get the [Google App Engine SDK/Launcher for Python](https://developers.google.com/appengine/downloads)
+4. pip install -t lib django
 5. `bin/compilelessc.sh` -- for Windows try [WinLESS](http://www.winless.org), and only compile the files listed in bin/compilelessc.sh, and set their output (by right clicking on the files) to /static/css.
    For MAC we have used SimpLESS, but have needed to apply this patch: https://gist.github.com/hlop/4951717
+   For Linux just run `npm install -g less`
 6. `bin/run.sh` or run in the Google App Engine Launcher and set to port 8081
 
 Detailed Setup Instructions:

--- a/WhySaurus.py
+++ b/WhySaurus.py
@@ -2,8 +2,11 @@ import constants
 import os
 import jinja2
 
-from google.appengine.ext import ndb
+from google.appengine.ext import ndb, vendor
 from google.appengine.ext.webapp import template
+
+# needs to be above django import and django must be in lib dir
+vendor.add('lib')
 from django.template import Library
 from google.appengine.ext import webapp
 

--- a/app.yaml
+++ b/app.yaml
@@ -1,3 +1,5 @@
+application: whysaurustest
+version: a
 runtime: python27
 api_version: 1
 threadsafe: true

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -11,4 +11,4 @@ if [ -z "${GAE_ROOT}" ]; then
 	exit 1
 fi
 
-$GAE_ROOT/dev_appserver.py --log_level debug --dev_appserver_log_level debug --port 8081 app.yaml
+$GAE_ROOT/dev_appserver.py --log_level debug --dev_appserver_log_level debug --port 8081 app.yaml $*

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -1,7 +1,7 @@
 //
 // Navbars (Redux)
 // --------------------------------------------------
-
+@import "variables.less";
 
 // COMMON STYLES
 // -------------
@@ -196,7 +196,7 @@
 .navbar-static-top .container,
 .navbar-fixed-top .container,
 .navbar-fixed-bottom .container {
-  #grid > .core > .span(@gridColumns);
+  #grid > .core { .span (@gridColumns); }
 }
 
 // Fixed to top

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.0",
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-gae": "^0.2.4"
+    "grunt-gae": "^0.2.4",
+    "grunt-shell-spawn": "^0.3.10"
   },
   "dependencies": {
     "grunt": "0.4.x",
@@ -18,7 +19,7 @@
     "grunt-preprocess": "^4.0.0",
     "grunt-rename": "^0.1.3",
     "grunt-shell": "0.3.x",
-    "grint-gae":"0.2.x"
+    "grunt-gae": "0.2.x"
   },
   "scripts": {
     "start": "grunt local"


### PR DESCRIPTION
you might want to take some of these without taking everything.

Enumerating setup issues:
* current SDK does not seem to have django available (anymore)? so django import failed.  I did not check django in to lib (that would be crazy), but need it in lib/ with the `vendor('lib')` for it to be available
* google app engine sdk seems to have a bug that loses the app_id in the yaml and it gets overridden by the text "None" without a `-A whysaurustest` addition.  I add a `$*` to the shell script so I can easily add those arguments to the run command.
* lessc version 2.7.2 reports a syntax error on the `navbar.less` line changed -- I tweaked it to the closest thing that validated.
* a syntax error and missing dev package in package.json