### PR TITLE
Backup scripts utilizing the import/export API

### DIFF
--- a/bin/backup-whysaurus-db
+++ b/bin/backup-whysaurus-db
@@ -2,6 +2,9 @@
 
 PROJECT_ID=whysaurus
 gcloud config set project ${PROJECT_ID}
+
+# this line will open a browser and force the user to manually authenticate. this
+# will not work in an automated environment.
 gcloud auth login
 BUCKET="com-whysaurus-datastore-backups"
 

--- a/bin/backup-whysaurus-db
+++ b/bin/backup-whysaurus-db
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+PROJECT_ID=whysaurus
+gcloud config set project ${PROJECT_ID}
+gcloud auth login
+BUCKET="com-whysaurus-datastore-backups"
+
+gcloud beta datastore export --namespaces="(default)" gs://${BUCKET}
+
+

--- a/bin/restore-whysaurustest-db-from-whysaurus-backup
+++ b/bin/restore-whysaurustest-db-from-whysaurus-backup
@@ -7,6 +7,8 @@ fi
 
 PROJECT_ID="whysaurustest"
 gcloud config set project ${PROJECT_ID}
+# this line will open a browser and force the user to manually authenticate. this
+# will not work in an automated environment.
 gcloud auth login
 BUCKET="com-whysaurus-datastore-backups"
 

--- a/bin/restore-whysaurustest-db-from-whysaurus-backup
+++ b/bin/restore-whysaurustest-db-from-whysaurus-backup
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ $1 -eq 0 ]] ; then
+    echo 'Please supply the backup name as an argument, for example, "2017-10-17T19:31:44_80592". You can find backups here: https://console.cloud.google.com/storage/browser/com-whysaurus-datastore-backups/?project=whysaurus'
+    exit 1
+fi
+
+PROJECT_ID="whysaurustest"
+gcloud config set project ${PROJECT_ID}
+gcloud auth login
+BUCKET="com-whysaurus-datastore-backups"
+
+gcloud beta datastore import gs://${BUCKET}/$1/$1.overall_export_metadata
+


### PR DESCRIPTION
Based on documentation here:

https://cloud.google.com/datastore/docs/export-import-entities

These scripts are intended to be used from the command line, and are simple enough to serve as documentation of the backup process.

The runbook has been updated here:

https://docs.google.com/document/d/1qyjcUeEZ44ENJZpm5_h8FuxgG6yR1AqCAYq5Cq68xZE/edit