### PR TITLE
Insert new evidence at the end of the list

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -149,6 +149,10 @@ class AddEvidence(graphene.Mutation):
 
     point = graphene.Field(Point)
 
+    newEdges = relay.ConnectionField(SubPointConnection)
+    def resolve_newEdges(self, info, **args):
+        return [self.point]
+
     def mutate(self, info, point_data):
         oldPoint, oldPointRoot = PointModel.getCurrentByUrl(point_data.parentURL)
         newPoint, newLinkPoint = PointModel.addSupportingPoint(
@@ -165,7 +169,11 @@ class AddEvidence(graphene.Mutation):
             sourcesNames=point_data.sourceNames
         )
 
-        return AddEvidence(point=newPoint)
+        # these two are in service of the SubPointConnection logic - we should find a way to DRY this up
+        newLinkPoint.parent = newPoint
+        newLinkPoint.link_type = point_data.linkType
+
+        return AddEvidence(point=newLinkPoint)
 
 class EditPointInput(graphene.InputObjectType):
     url = graphene.String(required=True)

--- a/static/js/ys/point.js
+++ b/static/js/ys/point.js
@@ -30,12 +30,18 @@ fragment pointFields on Point {
   currentUserVote
 }
 `
+export const evidenceEdgesFragment = gql`
+fragment evidenceEdges on SubPointConnection {
+  edges { node { title, upVotes, ...pointFields }, link { id, type, relevance, parentURLsafe, childURLsafe }}
+}`
+
 
 export const expandedPointFieldsFragment = gql`
 ${pointFieldsFragment}
+${evidenceEdgesFragment}
 fragment evidenceFields on Point {
- supportingPoints { edges { node { title, upVotes, ...pointFields }, link { id, type, relevance, parentURLsafe, childURLsafe }} },
- counterPoints { edges { node { title, upVotes, ...pointFields }, link { id, type, relevance, parentURLsafe, childURLsafe }} }
+ supportingPoints { ...evidenceEdges },
+ counterPoints { ...evidenceEdges }
 }`
 
 export const EvidenceType = Object.freeze({
@@ -323,11 +329,23 @@ class AddEvidenceCard extends React.Component {
 
   handleClickSave(values, e, formApi) {
     console.log("saving evidence")
-    values.parentURL = this.point.url
+    let parentURL = this.point.url
+    values.parentURL = parentURL
     values.linkType = this.linkType
     this.setState({saving: true})
     this.props.mutate({
-      variables: values
+      variables: values,
+      update: (proxy, { data: { addEvidence: { newEdges } }}) => {
+        const data = proxy.readQuery({ query: GetPoint, variables: {url: parentURL} })
+        if (this.linkType == 'counter') {
+          data.point.counterPoints.edges = data.point.counterPoints.edges.concat(newEdges.edges)
+        } else {
+          data.point.supportingPoints.edges = data.point.supportingPoints.edges.concat(newEdges.edges)
+        }
+        proxy.writeQuery({ query: GetPoint,
+                           variables: {url: parentURL},
+                           data: data });
+      }
     })
       .then( res => {
         this.setState({saving: false,
@@ -397,13 +415,11 @@ class AddEvidenceCard extends React.Component {
 }
 
 export const AddEvidenceQuery = gql`
-${expandedPointFieldsFragment}
+${pointFieldsFragment}
+${evidenceEdgesFragment}
 mutation AddEvidence($title: String!, $linkType: String, $parentURL: String, $imageURL: String, $imageAuthor: String, $imageDescription: String, $sourceURLs: [String], $sourceNames: [String]) {
   addEvidence(pointData: {title: $title, content: $title, summaryText: $title, imageURL: $imageURL, imageAuthor: $imageAuthor, imageDescription: $imageDescription, sourceURLs: $sourceURLs, sourceNames: $sourceNames, linkType: $linkType, parentURL: $parentURL}) {
-    point {
-    ...pointFields,
-    ...evidenceFields
-    }
+    newEdges { ...evidenceEdges }
   }
 }
 `


### PR DESCRIPTION
Change the evidence query to only return the newly created
edge. Insert the edge at the end of the list to avoid confusing
users. When they reload the order will change, but that is totally
fine for now.