### PR TITLE
Refresh parent point attributes after new subpoint is created

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -172,6 +172,7 @@ class AddEvidence(graphene.Mutation):
     class Arguments:
         point_data = PointInput(required=True)
 
+    parent = graphene.Field(Point)
     point = graphene.Field(Point)
 
     newEdges = relay.ConnectionField(SubPointConnection)
@@ -198,7 +199,7 @@ class AddEvidence(graphene.Mutation):
         newLinkPoint.parent = newPoint
         newLinkPoint.link_type = point_data.linkType
 
-        return AddEvidence(point=newLinkPoint)
+        return AddEvidence(point=newLinkPoint, parent=newPoint)
 
 class EditPointInput(graphene.InputObjectType):
     url = graphene.String(required=True)

--- a/static/js/ys/point.js
+++ b/static/js/ys/point.js
@@ -439,6 +439,7 @@ ${evidenceEdgesFragment}
 mutation AddEvidence($title: String!, $linkType: String, $parentURL: String, $imageURL: String, $imageAuthor: String, $imageDescription: String, $sourceURLs: [String], $sourceNames: [String]) {
   addEvidence(pointData: {title: $title, content: $title, summaryText: $title, imageURL: $imageURL, imageAuthor: $imageAuthor, imageDescription: $imageDescription, sourceURLs: $sourceURLs, sourceNames: $sourceNames, linkType: $linkType, parentURL: $parentURL}) {
     newEdges { ...evidenceEdges }
+    parent { id, numSupporting, numCounter } 
   }
 }
 `
@@ -869,7 +870,7 @@ class PointCard extends React.Component {
   evidence() {
     if (this.expanded() ) {
       // If this is the first level down, remove an indent bc the Relevance widget effectively creates one when it appears for the first time
-      let classesEvidenceBlock = `evidenceBlock ${!this.props.parentPoint ? "removeOneIndent" : null} ${this.numSupportingPlusCounter() == 0 ? "evidenceBlockEmpty" : null}`
+      let classesEvidenceBlock = `evidenceBlock ${!this.props.parentPoint ? "removeOneIndent" : null} ${this.numSupportingPlusCounter() == 0 ? "evidenceBlockEmpty" : ""}`
       let classesEvidenceArrow = `evidenceBlock ${!this.props.parentPoint ? "removeOneIndent" : null}`
       console.log("pointCard : evidence() ")
       const singleColumnThreshold = 1224;


### PR DESCRIPTION
This fixes an issue Josh noticed around initial subpoint creation