### PR TITLE
    First pass at existing claim adder

### DIFF
--- a/schema.py
+++ b/schema.py
@@ -354,6 +354,15 @@ class Query(graphene.ObjectType):
         if (user):
             return User(url=user.url, admin=user.isAdmin, role=user.role)
 
+    search = graphene.List(Point, query=graphene.String(required=True))
+    def resolve_search(self, info, **args):
+        searchResultsFuture = PointModel.search(
+            user=info.context.current_user,
+            searchTerms=args['query']
+        )
+        searchResults = searchResultsFuture.get_result() if searchResultsFuture else []
+        return searchResults
+
 class Mutation(graphene.ObjectType):
     delete = Delete.Field()
     unlink = Unlink.Field()

--- a/schema.py
+++ b/schema.py
@@ -16,6 +16,7 @@ class User(graphene.ObjectType):
     url = graphene.String()
     role = graphene.String()
     admin = graphene.Boolean()
+    recentlyViewed = graphene.List(lambda: Point)
 
 class Source(NdbObjectType):
     class Meta:
@@ -352,7 +353,8 @@ class Query(graphene.ObjectType):
     def resolve_currentUser(self, info):
         user = info.context.current_user
         if (user):
-            return User(url=user.url, admin=user.isAdmin, role=user.role)
+            # TODO: this is really not ideal, but I can't figure out how to get WhysaurusUser working as a Meta-defined model :-( TV
+            return User(url=user.url, admin=user.isAdmin, role=user.role, recentlyViewed=user.getRecentlyViewed())
 
     search = graphene.List(Point, query=graphene.String(required=True))
     def resolve_search(self, info, **args):

--- a/static/js/test/ClaimSearch.test.jsx
+++ b/static/js/test/ClaimSearch.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import ClaimSearch from '../ys/components/ClaimSearch'
+import renderer from 'react-test-renderer'
+
+test('ClaimSearch component renders', () => {
+  const component = renderer.create(
+    <ClaimSearch query="hams"
+                 render={({results, searching}) => {
+                   if (searching){
+                     return <div>Searching...</div>
+                   } else {
+                     return JSON.stringify(result)
+                   }
+      }}/>
+  )
+
+  let tree = component.toJSON()
+  expect(tree).toMatchSnapshot()
+  //TODO: figure out how to mock data from the apollo client here
+  //TODO: add enzyme and do real dom testing
+});

--- a/static/js/ys/components/AddEvidence.jsx
+++ b/static/js/ys/components/AddEvidence.jsx
@@ -1,0 +1,186 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { graphql, compose } from 'react-apollo';
+
+import * as schema from '../schema';
+import AddEvidenceForm from './AddEvidenceForm'
+
+class AddEvidence extends React.Component {
+  state = {addingSupport: false, addingCounter: false }
+
+  get point() {
+    return this.props.point;
+  }
+
+  get uiType(){
+    return this.props.type
+  }
+
+  get adding() {
+    return this.state.addingSupport || this.state.addingCounter
+  }
+
+  handleClickAddEvidenceSupport = (e) => {
+    if (this.props.user){
+      this.setState({addingSupport: true, addingCounter: false})
+    } else {
+      $("#loginDialog").modal("show");
+    }
+  }
+
+  handleClickAddEvidenceCounter = (e) => {
+    if (this.props.user){
+      this.setState({addingSupport: false, addingCounter: true})
+    } else {
+      $("#loginDialog").modal("show");
+    }
+  }
+
+  handleClickCancel = (e) => {
+    e.stopPropagation();
+    this.setState({addingSupport: false, addingCounter: false})
+    console.log("AddEvidenceCard : handleCancel")
+  }
+
+  handleClickSave = (evidenceType, values, e, formApi) => {
+    let parentURL = this.point.url
+    values.parentURL = parentURL
+    values.linkType = evidenceType
+    this.setState({saving: true})
+    this.props.mutate({
+      variables: values,
+      update: (proxy, { data: { addEvidence: { newEdges } }}) => {
+        const data = proxy.readQuery({ query: schema.GetPoint, variables: {url: parentURL} })
+        data.point.relevantPoints.edges = data.point.relevantPoints.edges.concat(newEdges.edges)
+        let points = data.point[evidenceType == "supporting" ? "supportingPoints" : "counterPoints"]
+        points.edges = points.edges.concat(newEdges.edges)
+        proxy.writeQuery({ query: schema.GetPoint,
+                           variables: {url: parentURL},
+                           data: data })
+      }
+    }).then( res => {
+      this.setState({saving: false,
+                     addingSupport: false,
+                     addingCounter: false})
+      console.log(res)
+    })
+  }
+
+  handleClickSaveSupport = (values, e, formApi) => {
+    this.handleClickSave("supporting", values, e, formApi)
+  }
+
+  handleClickSaveCounter = (values, e, formApi) => {
+    this.handleClickSave("counter", values, e, formApi)
+  }
+
+  addExistingClaim = (claim) => {
+    console.log("ADDING EXISTING CLAIM")
+    console.log(claim)
+    console.log("TODO: UNIMPLEMENTED")
+  }
+
+  renderAddEvidenceForm = (evidenceType) => {
+    console.log("AddEvidenceCard : renderAddEvidenceForm : " + evidenceType)
+    let groupClass = `${(this.numSupportingPlusCounter() > 0) && "verticalOffsetForLongEvidenceArrow"}`
+    return <span className={groupClass}>
+      { this.state.saving ? <span className="addEvidenceFormSaving"><img id="spinnerImage" className="spinnerPointSubmitButtonPosition" src="/static/img/ajax-loader.gif"/>Saving...</span> :
+        <AddEvidenceForm evidenceType={evidenceType} onSubmit={evidenceType=="supporting" ? this.handleClickSaveSupport : this.handleClickSaveCounter} onCancel={this.handleClickCancel} addExistingClaim={this.addExistingClaim}/> }
+    </span>
+  }
+
+  addText = (evidenceType) => {
+    switch (evidenceType){
+      case "supporting":
+        return "Add Evidence For"
+      case "counter":
+        return "Add Evidence Against"
+      default:
+        return "Add Evidence"
+    }
+  }
+
+  numSupportingPlusCounter = () => {
+    return (this.point.numSupporting + this.point.numCounter)
+  }
+
+  renderAddEvidenceFormBasedOnState = () => {
+    if (this.state.addingSupport) {
+      return <span>
+        {this.renderAddEvidenceForm("supporting")}
+      </span>
+    } else if (this.state.addingCounter) {
+      return <span>
+        {this.renderAddEvidenceForm("counter")}
+      </span>
+    }
+    else return (null)
+  }
+
+  renderAddEvidenceButton = (evidenceType) => {
+    let classesButton = `buttonUX2 ${evidenceType=="counter" ? "buttonUX2Red" : ""} addEvidenceButton`
+    let nameButton = `${evidenceType=="counter" ? "addCounterEvidenceButton" : "addSupportingEvidenceButton" }`
+    let buttonLabel = this.addText(evidenceType)
+    let aClass = `${(this.numSupportingPlusCounter() > 0) && "verticalOffsetForLongEvidenceArrow"}`
+    let onClick = evidenceType == 'supporting' ? this.handleClickAddEvidenceSupport : this.handleClickAddEvidenceCounter
+    return <a className={aClass} onClick={onClick}>
+      <button type="button" name={nameButton} tabIndex="0" className={classesButton}>{buttonLabel}</button>
+    </a>
+  }
+
+  renderSupportButton = () => this.renderAddEvidenceButton("supporting")
+
+  renderCounterButton = () => this.renderAddEvidenceButton("counter")
+
+  renderDualButtons = () => <span>
+    {this.renderSupportButton()}
+    {this.renderCounterButton()}
+  </span>
+
+  renderEvidenceArrow = (color) => {
+    let arrowGrpClass = `arrowEvidence ${(this.numSupportingPlusCounter() > 0) && "verticalOffsetForLongEvidenceArrow"}`
+    let arrowHeadClass = `arrowHeadUp ${color == "red" && "arrowHeadUpRed"}`
+    let arrowStemClass = `arrowStemEvidence ${(this.numSupportingPlusCounter() == 0) && "arrowStemEvidenceShort" } ${color == "red" && "arrowStemRed"}`
+    return <div className={arrowGrpClass}>
+      <div className={arrowHeadClass}></div>
+      <div className={arrowStemClass}></div>
+    </div>
+  }
+
+  render() {
+    let topDivClass = `addEvidenceUI`
+    switch (this.uiType) {
+    case "DUAL":
+      return <div className={topDivClass}>
+        { this.renderEvidenceArrow() }
+        { (this.adding) ? this.renderAddEvidenceFormBasedOnState() : this.renderDualButtons() }
+      </div>
+    case "SUPPORT":
+      return <div className={topDivClass}>
+        { this.renderEvidenceArrow() }
+        { this.state.addingSupport ? this.renderAddEvidenceForm("supporting") : this.renderSupportButton() }
+      </div>
+    case "COUNTER":
+      return <div className={topDivClass}>
+        { this.renderEvidenceArrow("red") }
+        { this.state.addingCounter ? this.renderAddEvidenceForm("counter") : this.renderCounterButton() }
+      </div>
+    default:
+      console.log("AddEvidenceCard : render() : something's wrong!")
+      return <div className={topDivClass}>
+      </div>
+    }
+  }
+}
+
+
+export default compose(
+  graphql(schema.AddEvidenceQuery),
+  graphql(schema.CurrentUserQuery, {
+    props: ({ownProps, data: {loading, currentUser, refetch}}) => ({
+      userLoading: loading,
+      user: currentUser,
+      refetchUser: refetch
+    })
+  })
+)(AddEvidence)

--- a/static/js/ys/components/AddEvidenceForm.jsx
+++ b/static/js/ys/components/AddEvidenceForm.jsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Form, Text } from 'react-form';
+import { graphql } from 'react-apollo';
+
+import * as validations from '../validations';
+import * as schema from '../schema';
+import TitleText from './TitleText'
+import ClaimSearch from './ClaimSearch'
+
+// use onmousedown here to try to get in before blur hides the UI (see note in TitleText onBlur below)
+// TODO: check in with Josh to see if we can come up with better "hide" conditions so we can avoid this
+const ExistingClaimPicker = ({claims, onSelectClaim}) => <ul>
+      {claims && claims.map((claim) => <li onMouseDown={e => onSelectClaim(claim, e)} key={claim.id}>
+                            {claim.title}
+                            </li>)}
+      </ul>
+
+class AddEvidenceForm extends React.Component {
+
+  static propTypes = {
+    addExistingClaim: PropTypes.func.isRequired,
+    onSubmit: PropTypes.func.isRequired,
+    onCancel: PropTypes.func.isRequired
+  }
+
+  state = {titleTextFocused: false}
+
+  selectExistingClaim = (claim) => {
+    this.props.addExistingClaim(claim)
+  }
+
+  existingClaimPicker = (titleValue, searchResults, searching) => {
+    if (this.state.titleTextFocused) {
+      if (titleValue && (titleValue != '')){
+        if (searching) {
+          return <div>Searching...</div>
+        } else {
+          return <ExistingClaimPicker claims={searchResults} onSelectClaim={this.selectExistingClaim}/>
+        }
+      } else if (this.props.user) {
+        return <ExistingClaimPicker claims={this.props.user.recentlyViewed} onSelectClaim={this.selectExistingClaim}/>
+      }
+    }
+  }
+
+
+  render(){
+    const {userLoading, user} = this.props
+    let submitClasses = `buttonUX2 addEvidenceFormButton ${this.props.evidenceType=="counter" ? "buttonUX2Red" : ""}`
+    return <Form onSubmit={this.props.onSubmit}
+                 validate={values => ({title: validations.validateTitle(values.title)})}>
+      { ({submitForm, values: {title}}) => (
+        <ClaimSearch
+          query={title}
+          render={({results, searching}) =>
+                  <form onSubmit={submitForm} className="addEvidenceForm">
+                      <TitleText id="title" className="addEvidenceFormTextField"
+                                   placeholder='Make a claim, eg "Dogs can learn more tricks than cats."'
+                                   onFocus={() => {this.setState({titleTextFocused: true})}}
+                                   // use the setTimeout here to allow the mousedown event in existingclaimpicker to fire consistently
+                                   // right now this fires before the onClick in ExistingClaimPIcker and hides that UI before the click event can be fired
+                                   // TODO: check in with josh to see if we can come up with better "hide" conditions
+                                   onBlur={() => {setTimeout(() => this.setState({titleTextFocused: false}), 100)}}
+                          />
+                          {this.existingClaimPicker(title, results, searching)}
+                        <button type="submit" className={submitClasses}>Add</button>
+                          <button type="cancel" className="cancelButton cancelButtonAddEvidence" onClick={this.props.onCancel}>Cancel</button>
+                    </form>
+                  }/>
+      )}
+    </Form>
+  }
+}
+
+export default graphql(schema.CurrentUserQuery, {
+  props: ({ownProps, data: {loading, currentUser, refetch}}) => ({
+    userLoading: loading,
+    user: currentUser,
+    refetchUser: refetch
+  })
+})(AddEvidenceForm)

--- a/static/js/ys/components/AddEvidenceForm.jsx
+++ b/static/js/ys/components/AddEvidenceForm.jsx
@@ -9,7 +9,7 @@ import TitleText from './TitleText'
 import ClaimSearch from './ClaimSearch'
 
 // use onmousedown here to try to get in before blur hides the UI (see note in TitleText onBlur below)
-// TODO: check in with Josh to see if we can come up with better "hide" conditions so we can avoid this
+// TODO: think about ways to make the "suggestion UI hide" condition be "clicking on anything that is not the text input or suggestion ui itself"
 const ExistingClaimPicker = ({claims, onSelectClaim}) => <ul>
       {claims && claims.map((claim) => <li onMouseDown={e => onSelectClaim(claim, e)} key={claim.id}>
                             {claim.title}
@@ -56,16 +56,17 @@ class AddEvidenceForm extends React.Component {
           render={({results, searching}) =>
                   <form onSubmit={submitForm} className="addEvidenceForm">
                       <TitleText id="title" className="addEvidenceFormTextField"
+                                   autoComplete='off'
                                    placeholder='Make a claim, eg "Dogs can learn more tricks than cats."'
                                    onFocus={() => {this.setState({titleTextFocused: true})}}
                                    // use the setTimeout here to allow the mousedown event in existingclaimpicker to fire consistently
                                    // right now this fires before the onClick in ExistingClaimPIcker and hides that UI before the click event can be fired
-                                   // TODO: check in with josh to see if we can come up with better "hide" conditions
+                                   // TODO: think about ways to make the "suggestion UI hide" condition be "clicking on anything that is not the text input or suggestion ui itself"
                                    onBlur={() => {setTimeout(() => this.setState({titleTextFocused: false}), 100)}}
                           />
-                          {this.existingClaimPicker(title, results, searching)}
-                        <button type="submit" className={submitClasses}>Add</button>
-                          <button type="cancel" className="cancelButton cancelButtonAddEvidence" onClick={this.props.onCancel}>Cancel</button>
+                      {this.existingClaimPicker(title, results, searching)}
+                      <button type="submit" className={submitClasses}>Add</button>
+                      <button type="cancel" className="cancelButton cancelButtonAddEvidence" onClick={this.props.onCancel}>Cancel</button>
                     </form>
                   }/>
       )}

--- a/static/js/ys/components/AddEvidenceForm.jsx
+++ b/static/js/ys/components/AddEvidenceForm.jsx
@@ -18,6 +18,11 @@ const ExistingClaimPicker = ({claims, onSelectClaim}) => <ul>
 
 class AddEvidenceForm extends React.Component {
 
+  constructor(props) {
+    super(props)
+    this.currentSupportingClaimURLs = new Set(this.props.currentSupportingClaims.map(claim => claim.url))
+  }
+
   static propTypes = {
     addExistingClaim: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
@@ -26,9 +31,11 @@ class AddEvidenceForm extends React.Component {
 
   state = {titleTextFocused: false}
 
-  selectExistingClaim = (claim) => {
-    this.props.addExistingClaim(claim)
-  }
+  selectExistingClaim = (claim) =>
+    this.props.addExistingClaim(this.props.evidenceType, claim)
+
+  filterCurrentSupport = (claims) =>
+    this.props.currentSupportingClaims ? claims.filter(claim => !this.currentSupportingClaimURLs.has(claim.url)) : claims
 
   existingClaimPicker = (titleValue, searchResults, searching) => {
     if (this.state.titleTextFocused) {
@@ -36,10 +43,10 @@ class AddEvidenceForm extends React.Component {
         if (searching) {
           return <div>Searching...</div>
         } else {
-          return <ExistingClaimPicker claims={searchResults} onSelectClaim={this.selectExistingClaim}/>
+          return <ExistingClaimPicker claims={this.filterCurrentSupport(searchResults)} onSelectClaim={this.selectExistingClaim}/>
         }
       } else if (this.props.user) {
-        return <ExistingClaimPicker claims={this.props.user.recentlyViewed} onSelectClaim={this.selectExistingClaim}/>
+        return <ExistingClaimPicker claims={this.filterCurrentSupport(this.props.user.recentlyViewed)} onSelectClaim={this.selectExistingClaim}/>
       }
     }
   }

--- a/static/js/ys/components/ClaimSearch.jsx
+++ b/static/js/ys/components/ClaimSearch.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { graphql } from 'react-apollo';
+import * as schema from '../schema';
+
+class ClaimSearch extends React.Component {
+  static propTypes = {
+    render: PropTypes.func.isRequired
+  }
+
+  render(){
+    const {search, loading} = this.props.data || {}
+    return (
+      this.props.render({results: search, searching: loading})
+    )
+  }
+}
+
+export default graphql(schema.Search, {
+  skip: (ownProps) => !ownProps.query || (ownProps.query == '')
+})(ClaimSearch)

--- a/static/js/ys/point.js
+++ b/static/js/ys/point.js
@@ -9,6 +9,7 @@ import * as validations from './validations';
 import * as formUtils from './form_utils.js';
 import { UnlinkPointMutation, DeletePointMutation, CurrentUserQuery, EditPointQuery, AddEvidenceQuery, VoteQuery, RelevanceVoteQuery, GetPoint, GetCollapsedPoint, EditorsPicks, NewPoints } from './schema.js';
 import {PointList} from './point_list.js'
+import AddEvidenceForm from './components/AddEvidenceForm'
 
 // TODO: make work
 //import Arrow from '@elsdoerfer/react-arrow';
@@ -279,30 +280,6 @@ class EvidenceLink extends React.Component {
   }
 }
 
-// TODO : depending on user tests, maybe add <div className="addEvidenceFormLabel">Add evidence this list</div>
-const AddEvidenceFormComponent = ( props ) => {
-  let submitClasses = `buttonUX2 addEvidenceFormButton ${props.evidenceType=="counter" ? "buttonUX2Red" : ""}`
-  return (
-    <div className="addEvidenceFormGroup">
-      <Form onSubmit={props.onSubmit}
-            validate={values => ({title: validations.validateTitle(values.title)})}
-            dontValidateOnMount={true}>
-      { formApi => (
-          <form onSubmit={formApi.submitForm} id="form1" className="addEvidenceForm">
-          <Text onChange={props.updateCharCount} field="title" id="title" className="addEvidenceFormTextField" placeholder='Make a claim, eg "Dogs can learn more tricks than cats."' />
-          <p>{formApi.errors && formApi.errors.title}</p>
-          <p className={props.charsLeft && props.charsLeft < 0 ? 'overMaxChars' : ''}>{props.charsLeft}</p>
-          <button type="submit" className={submitClasses}>Add</button>
-          <button type="cancel" className="cancelButton cancelButtonAddEvidence" onClick={props.onCancel}>Cancel</button>
-          </form>
-      )}
-    </Form>
-  </div>
-  );
-}
-
-const AddEvidenceForm = formUtils.withCharCount(AddEvidenceFormComponent, validations.titleMaxCharacterCount);
-
 class AddEvidenceCard extends React.Component {
   constructor(props) {
     super(props)
@@ -398,11 +375,18 @@ class AddEvidenceCard extends React.Component {
       });
   }
 
+  addExistingClaim = (claim) => {
+    console.log("ADDING EXISTING CLAIM")
+    console.log(claim)
+    console.log("TODO: UNIMPLEMENTED")
+  }
+
   renderAddEvidenceForm(evidenceType) {
     console.log("AddEvidenceCard : renderAddEvidenceForm : " + evidenceType)
     let groupClass = `${(this.numSupportingPlusCounter() > 0) && "verticalOffsetForLongEvidenceArrow"}`
     return <span className={groupClass}>
-        { this.state.saving ? <span className="addEvidenceFormSaving"><img id="spinnerImage" className="spinnerPointSubmitButtonPosition" src="/static/img/ajax-loader.gif"/>Saving...</span> : <AddEvidenceForm evidenceType={evidenceType} onSubmit={evidenceType=="support" ? this.handleClickSaveSupport : this.handleClickSaveCounter} onCancel={this.handleClickCancel}/> }
+      { this.state.saving ? <span className="addEvidenceFormSaving"><img id="spinnerImage" className="spinnerPointSubmitButtonPosition" src="/static/img/ajax-loader.gif"/>Saving...</span> :
+        <AddEvidenceForm evidenceType={evidenceType} onSubmit={evidenceType=="support" ? this.handleClickSaveSupport : this.handleClickSaveCounter} onCancel={this.handleClickCancel} addExistingClaim={this.addExistingClaim}/> }
     </span>
   }
 

--- a/static/js/ys/point.js
+++ b/static/js/ys/point.js
@@ -165,7 +165,7 @@ class PointComponent extends React.Component {
   // TODO: set prevScore correctly, somehow
   render(){
     const score = this.point.pointValue
-        const prevScore = this.point.pointValue
+    const prevScore = this.point.pointValue
     return <div>
       {this.titleUI()}
     <span className="scoreAnimContainerMax score">

--- a/static/js/ys/point.js
+++ b/static/js/ys/point.js
@@ -9,14 +9,14 @@ import * as validations from './validations';
 import * as formUtils from './form_utils.js';
 import { UnlinkPointMutation, DeletePointMutation, CurrentUserQuery, EditPointQuery, AddEvidenceQuery, VoteQuery, RelevanceVoteQuery, GetPoint, GetCollapsedPoint, EditorsPicks, NewPoints } from './schema.js';
 import {PointList} from './point_list.js'
-import AddEvidenceForm from './components/AddEvidenceForm'
+import AddEvidence from './components/AddEvidence'
 
 // TODO: make work
 //import Arrow from '@elsdoerfer/react-arrow';
 
 
 // For Responsive
-// TO DO : this is also declared in home.js, lets set it up to live in a single place
+// TODO : this is also declared in home.js, lets set it up to live in a single place
 const singleColumnThreshold = 960;
 
 export const EvidenceType = Object.freeze({
@@ -279,180 +279,6 @@ class EvidenceLink extends React.Component {
   return <span className="evidenceContainer">{this.whichEvidenceButton()}</span>
   }
 }
-
-class AddEvidenceCard extends React.Component {
-  state = {addingSupport: false, addingCounter: false }
-
-  get point() {
-    return this.props.point;
-  }
-
-  get uiType(){
-    return this.props.type
-  }
-
-  get adding() {
-    return this.state.addingSupport || this.state.addingCounter
-  }
-
-  handleClickAddEvidenceSupport = (e) => {
-    if (this.props.CurrentUserQuery.currentUser){
-      this.setState({addingSupport: true, addingCounter: false})
-    } else {
-      $("#loginDialog").modal("show");
-    }
-  }
-
-  handleClickAddEvidenceCounter = (e) => {
-    if (this.props.CurrentUserQuery.currentUser){
-      this.setState({addingSupport: false, addingCounter: true})
-    } else {
-      $("#loginDialog").modal("show");
-    }
-  }
-
-  handleClickCancel = (e) => {
-    e.stopPropagation();
-    this.setState({addingSupport: false, addingCounter: false})
-    console.log("AddEvidenceCard : handleCancel")
-  }
-
-  handleClickSave = (evidenceType, values, e, formApi) => {
-    let parentURL = this.point.url
-    values.parentURL = parentURL
-    values.linkType = evidenceType
-    this.setState({saving: true})
-    this.props.mutate({
-      variables: values,
-      update: (proxy, { data: { addEvidence: { newEdges } }}) => {
-        const data = proxy.readQuery({ query: GetPoint, variables: {url: parentURL} })
-        data.point.relevantPoints.edges = data.point.relevantPoints.edges.concat(newEdges.edges)
-        let points = data.point[evidenceType == "supporting" ? "supportingPoints" : "counterPoints"]
-        points.edges = points.edges.concat(newEdges.edges)
-        proxy.writeQuery({ query: GetPoint,
-                           variables: {url: parentURL},
-                           data: data })
-      }
-    }).then( res => {
-      this.setState({saving: false,
-                     addingSupport: false,
-                     addingCounter: false})
-      console.log(res)
-    })
-  }
-
-  handleClickSaveSupport = (values, e, formApi) => {
-    this.handleClickSave("supporting", values, e, formApi)
-  }
-
-  handleClickSaveCounter = (values, e, formApi) => {
-    this.handleClickSave("counter", values, e, formApi)
-  }
-
-  addExistingClaim = (claim) => {
-    console.log("ADDING EXISTING CLAIM")
-    console.log(claim)
-    console.log("TODO: UNIMPLEMENTED")
-  }
-
-  renderAddEvidenceForm = (evidenceType) => {
-    console.log("AddEvidenceCard : renderAddEvidenceForm : " + evidenceType)
-    let groupClass = `${(this.numSupportingPlusCounter() > 0) && "verticalOffsetForLongEvidenceArrow"}`
-    return <span className={groupClass}>
-      { this.state.saving ? <span className="addEvidenceFormSaving"><img id="spinnerImage" className="spinnerPointSubmitButtonPosition" src="/static/img/ajax-loader.gif"/>Saving...</span> :
-        <AddEvidenceForm evidenceType={evidenceType} onSubmit={evidenceType=="supporting" ? this.handleClickSaveSupport : this.handleClickSaveCounter} onCancel={this.handleClickCancel} addExistingClaim={this.addExistingClaim}/> }
-    </span>
-  }
-
-  addText = (evidenceType) => {
-    switch (evidenceType){
-      case "supporting":
-        return "Add Evidence For"
-      case "counter":
-        return "Add Evidence Against"
-      default:
-        return "Add Evidence"
-    }
-  }
-
-  numSupportingPlusCounter = () => {
-    return (this.point.numSupporting + this.point.numCounter)
-  }
-
-  renderAddEvidenceFormBasedOnState = () => {
-    if (this.state.addingSupport) {
-      return <span>
-        {this.renderAddEvidenceForm("supporting")}
-      </span>
-    } else if (this.state.addingCounter) {
-      return <span>
-        {this.renderAddEvidenceForm("counter")}
-      </span>
-    }
-    else return (null)
-  }
-
-  renderAddEvidenceButton = (evidenceType) => {
-    let classesButton = `buttonUX2 ${evidenceType=="counter" ? "buttonUX2Red" : ""} addEvidenceButton`
-    let nameButton = `${evidenceType=="counter" ? "addCounterEvidenceButton" : "addSupportingEvidenceButton" }`
-    let buttonLabel = this.addText(evidenceType)
-    let aClass = `${(this.numSupportingPlusCounter() > 0) && "verticalOffsetForLongEvidenceArrow"}`
-    let onClick = evidenceType == 'supporting' ? this.handleClickAddEvidenceSupport : this.handleClickAddEvidenceCounter
-    return <a className={aClass} onClick={onClick}>
-      <button type="button" name={nameButton} tabIndex="0" className={classesButton}>{buttonLabel}</button>
-    </a>
-  }
-
-  renderSupportButton = () => this.renderAddEvidenceButton("supporting")
-
-  renderCounterButton = () => this.renderAddEvidenceButton("counter")
-
-  renderDualButtons = () => <span>
-    {this.renderSupportButton()}
-    {this.renderCounterButton()}
-  </span>
-
-  renderEvidenceArrow = (color) => {
-    let arrowGrpClass = `arrowEvidence ${(this.numSupportingPlusCounter() > 0) && "verticalOffsetForLongEvidenceArrow"}`
-    let arrowHeadClass = `arrowHeadUp ${color == "red" && "arrowHeadUpRed"}`
-    let arrowStemClass = `arrowStemEvidence ${(this.numSupportingPlusCounter() == 0) && "arrowStemEvidenceShort" } ${color == "red" && "arrowStemRed"}`
-    return <div className={arrowGrpClass}>
-      <div className={arrowHeadClass}></div>
-      <div className={arrowStemClass}></div>
-    </div>
-  }
-
-  render() {
-    let topDivClass = `addEvidenceUI`
-    switch (this.uiType) {
-    case "DUAL":
-      return <div className={topDivClass}>
-        { this.renderEvidenceArrow() }
-        { (this.adding) ? this.renderAddEvidenceFormBasedOnState() : this.renderDualButtons() }
-      </div>
-    case "SUPPORT":
-      return <div className={topDivClass}>
-        { this.renderEvidenceArrow() }
-        { this.state.addingSupport ? this.renderAddEvidenceForm("supporting") : this.renderSupportButton() }
-      </div>
-    case "COUNTER":
-      return <div className={topDivClass}>
-        { this.renderEvidenceArrow("red") }
-        { this.state.addingCounter ? this.renderAddEvidenceForm("counter") : this.renderCounterButton() }
-      </div>
-    default:
-      console.log("AddEvidenceCard : render() : something's wrong!")
-      return <div className={topDivClass}>
-      </div>
-    }
-  }
-}
-
-
-const AddEvidence = compose(
-  graphql(AddEvidenceQuery),
-  graphql(CurrentUserQuery, {name: 'CurrentUserQuery'}),
-)(AddEvidenceCard)
 
 class AgreeDisagreeComponent extends React.Component {
   constructor(props) {

--- a/static/js/ys/schema.js
+++ b/static/js/ys/schema.js
@@ -66,6 +66,17 @@ mutation AddEvidence($title: String!, $linkType: String, $parentURL: String, $im
 }
 `
 
+export const LinkPoint = gql`
+${pointFieldsFragment}
+${evidenceEdgesFragment}
+mutation LinkPoint($parentURL: String!, $url: String!, $linkType: String!) {
+  linkPoint(parentURL: $parentURL, linkType: $linkType, url: $url) {
+    newEdges { ...evidenceEdges }
+    parent { id, numSupporting, numCounter }
+  }
+}
+`
+
 export const VoteQuery = gql`
 mutation Vote($url: String!, $vote: Int!, $parentURL: String) {
   vote(url: $url, vote: $vote, parentURL: $parentURL) {

--- a/static/js/ys/schema.js
+++ b/static/js/ys/schema.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 export const CurrentUserQuery = gql`
 query CurrentUser {
-  currentUser { url, admin, role }
+  currentUser { url, admin, role, recentlyViewed { id, url, title } }
 }`
 
 export const pointFieldsFragment = gql`

--- a/static/js/ys/schema.js
+++ b/static/js/ys/schema.js
@@ -138,6 +138,14 @@ query Point($url: String) {
  }
 }`
 
+export const Search = gql`
+${pointFieldsFragment}
+query Search($query: String!) {
+  search(query: $query) {
+    ...pointFields,
+  }
+}`
+
 export const HomePage = gql`
 ${pointFieldsFragment}
 query HomePage {

--- a/static/js/ys/schema.js
+++ b/static/js/ys/schema.js
@@ -139,10 +139,9 @@ query Point($url: String) {
 }`
 
 export const Search = gql`
-${pointFieldsFragment}
 query Search($query: String!) {
   search(query: $query) {
-    ...pointFields,
+    id, url, title
   }
 }`
 


### PR DESCRIPTION
    Implements:

    ```
    Option 2: Unified Text Field
    I think this is where we want to get to eventually. Feels fluid and elegant to me. Dunno how hard it is?

    Clicking Add Evidence brings up a text input field with placeholder text along the lines of “Make a claim or Search for an existing claim”
    Clicking inside the text input field brings up, below it, the Recently Viewed list
    If a user clicks on a Recently Viewed claim, it gets added
    If user starts to type, the Recently Viewed list is replaced by suggestions via Search.
    If searching on every keystroke is costly, we could search only on spacebar hits
    If user doesn’t see a suggestion s/he likes, user ends up typing in a new claim and clicks “Add”.
    ```