### PR TITLE
Refactor to allow us to render new claim title errors and suggestions in one place

### DIFF
--- a/static/js/ys/components/AddEvidence.jsx
+++ b/static/js/ys/components/AddEvidence.jsx
@@ -68,7 +68,6 @@ class AddEvidence extends React.Component {
       })
   }
 
-
   handleClickSaveSupport = (values, e, formApi) => {
     this.handleClickSave("supporting", values, e, formApi)
   }
@@ -77,23 +76,17 @@ class AddEvidence extends React.Component {
     this.handleClickSave("counter", values, e, formApi)
   }
 
-  supportingClaims = (evidenceType) => {
-    let connections = this.point[evidenceType == "supporting" ? "supportingPoints" : "counterPoints"]
-    return connections ? connections.edges.map(edge => edge.node) : []
-  }
-
   renderAddEvidenceForm = (evidenceType) => {
     console.log("AddEvidenceCard : renderAddEvidenceForm : " + evidenceType)
     let progressFeedbackClasses = `progressStateFeedback ${evidenceType=="counter" && "counter"}`
     return <span>
       { this.state.saving ? <div className={progressFeedbackClasses}><Spinner />Saving...</div> :
       <span className={(this.numSupportingPlusCounter() > 0) && "verticalOffsetForLongEvidenceArrowForm"}>
-        <AddEvidenceForm evidenceType={evidenceType}
-                           onSubmit={evidenceType=="supporting" ? this.handleClickSaveSupport : this.handleClickSaveCounter}
-                           onCancel={this.handleClickCancel}
-                           addExistingClaim={this.addExistingClaim}
-                           point={this.point}
-                           currentSupportingClaims={this.supportingClaims(evidenceType)}/> 
+        <AddEvidenceForm point={this.point}
+                         evidenceType={evidenceType}
+                         addExistingClaim={this.addExistingClaim}
+                         onSubmit={evidenceType=="supporting" ? this.handleClickSaveSupport : this.handleClickSaveCounter}
+                         onCancel={this.handleClickCancel}/>
       </span>}
     </span>
   }

--- a/static/js/ys/components/AddEvidenceForm.jsx
+++ b/static/js/ys/components/AddEvidenceForm.jsx
@@ -39,6 +39,7 @@ class AddEvidenceForm extends React.Component {
           <TitleText id="title" className="titleTextField"
                      autoComplete='off'
                      placeholder={this.generatePlaceholderText(evidenceType)}
+                     suggestExistingClaims={true}
                      point={point}
                      evidenceType={evidenceType}
                      addExistingClaim={addExistingClaim}/>

--- a/static/js/ys/components/AddEvidenceForm.jsx
+++ b/static/js/ys/components/AddEvidenceForm.jsx
@@ -8,57 +8,14 @@ import * as schema from '../schema';
 import TitleText from './TitleText'
 import ClaimSearch from './ClaimSearch'
 
-// use onmousedown here to try to get in before blur hides the UI (see note in TitleText onBlur below)
-// TODO: think about ways to make the "suggestion UI hide" condition be "clicking on anything that is not the text input or suggestion ui itself"
-const ExistingClaimPicker = ({claims, onSelectClaim}) => <ul className="ExistingClaimList">
-      {claims && claims.map((claim) => <li onMouseDown={e => onSelectClaim(claim, e)} key={claim.id}>
-                            {claim.title}
-                            </li>)}
-      </ul>
-
 class AddEvidenceForm extends React.Component {
-
-  constructor(props) {
-    super(props)
-    this.invalidEvidenceURLs = new Set([props.point.url, ...props.currentSupportingClaims.map(claim => claim.url)])
-  }
 
   static propTypes = {
     point: PropTypes.object.isRequired,
-    currentSupportingClaims: PropTypes.array.isRequired,
+    evidenceType: PropTypes.string.isRequired,
     addExistingClaim: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired
-  }
-
-  state = {titleTextFocused: false}
-
-  selectExistingClaim = (claim) =>
-    this.props.addExistingClaim(this.props.evidenceType, claim)
-
-  filterEvidenceCandidates = (claims) =>
-    claims.filter(claim => !this.invalidEvidenceURLs.has(claim.url))
-
-  existingClaimPicker = (titleValue, searchResults, searching) => {
-      if (titleValue && (titleValue != '')){
-        if (searching) {
-          return <div className="">Searching...</div>
-        } else {
-          return <ExistingClaimPicker claims={this.filterEvidenceCandidates(searchResults)} onSelectClaim={this.selectExistingClaim}/>
-        }
-      } else if (this.props.user) {
-        return <ExistingClaimPicker claims={this.filterEvidenceCandidates(this.props.user.recentlyViewed)} onSelectClaim={this.selectExistingClaim}/>
-      }
-  }
-
-  // if (this.state.titleTextFocused) {
-  existingClaimPickerDropdown = (titleValue, searchResults, searching) => {
-    if (this.state.titleTextFocused) {
-      return <div className="existingClaimPickerDropdown">
-        <div className="existingClaimPickerHeading">Existing Claims:</div>
-        {this.existingClaimPicker(titleValue, searchResults, searching)}
-      </div>
-    }
   }
 
   // TODO: add multiple options for each type and randomize to give it some fun magic!
@@ -73,42 +30,24 @@ class AddEvidenceForm extends React.Component {
   }
 
   render(){
-    const {userLoading, user} = this.props
-    let submitClasses = `buttonUX2 createClaimFormButton ${this.props.evidenceType=="counter" ? "buttonUX2Red" : ""}`
+    let submitClasses = `buttonUX2 addEvidenceFormButton ${this.props.evidenceType=="counter" ? "buttonUX2Red" : ""}`
+    let {point, evidenceType, addExistingClaim} = this.props
     return <Form onSubmit={this.props.onSubmit}
                  validate={values => ({title: validations.validateTitle(values.title)})}>
       { ({submitForm, values: {title}}) => (
-        <ClaimSearch
-          query={title}
-          render={({results, searching}) =>
-                  <form onSubmit={submitForm} className="addEvidenceForm">
-                      <div className="claimCreationFormFieldBlock">
-                        <TitleText id="title" className="titleTextField"
-                                   autoComplete='off'
-                                   placeholder={this.generatePlaceholderText(this.props.evidenceType)}
-                                   onFocus={() => {this.setState({titleTextFocused: true})}}
-                                   // use the setTimeout here to allow the mousedown event in existingclaimpicker to fire consistently
-                                   // right now this fires before the onClick in ExistingClaimPIcker and hides that UI before the click event can be fired
-                                   // TODO: think about ways to make the "suggestion UI hide" condition be "clicking on anything that is not the text input or suggestion ui itself"
-                                   onBlur={() => {setTimeout(() => this.setState({titleTextFocused: false}), 100)}}
-                        />
-                        {this.existingClaimPickerDropdown(title, results, searching)}
-                      </div>
-                      <div className="claimCreationFormButtonBlock">
-                        <button type="submit" className={submitClasses}>Add</button>
-                        <button type="cancel" className="cancelButton cancelButtonAddEvidence" onClick={this.props.onCancel}>Cancel</button>
-                      </div>
-                    </form>
-                  }/>
+        <form onSubmit={submitForm} className="addEvidenceForm">
+          <TitleText id="title" className="titleTextField"
+                     autoComplete='off'
+                     placeholder={this.generatePlaceholderText(evidenceType)}
+                     point={point}
+                     evidenceType={evidenceType}
+                     addExistingClaim={addExistingClaim}/>
+          <button type="submit" className={submitClasses}>Add</button>
+          <button type="cancel" className="cancelButton cancelButtonAddEvidence" onClick={this.props.onCancel}>Cancel</button>
+        </form>
       )}
     </Form>
   }
 }
 
-export default graphql(schema.CurrentUserQuery, {
-  props: ({ownProps, data: {loading, currentUser, refetch}}) => ({
-    userLoading: loading,
-    user: currentUser,
-    refetchUser: refetch
-  })
-})(AddEvidenceForm)
+export default AddEvidenceForm

--- a/static/js/ys/components/ClaimSuggestor.jsx
+++ b/static/js/ys/components/ClaimSuggestor.jsx
@@ -1,0 +1,61 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { compose, graphql } from 'react-apollo';
+import * as schema from '../schema';
+
+class ClaimSuggestor extends React.Component {
+  static propTypes = {
+    point: PropTypes.object,
+    evidenceType: PropTypes.string,
+    render: PropTypes.func.isRequired
+  }
+
+  constructor(props) {
+    super(props)
+    this.invalidEvidenceURLs = new Set([props.point.url, ...this.evidence().map(claim => claim.url)])
+  }
+
+  evidence = () => {
+    let connections = this.props.point[this.props.evidenceType == "supporting" ? "supportingPoints" : "counterPoints"]
+    return connections ? connections.edges.map(edge => edge.node) : []
+  }
+
+  filterEvidenceCandidates = (claims) =>
+    claims.filter(claim => !this.invalidEvidenceURLs.has(claim.url))
+
+  suggestions = () => {
+    const {user, query, searchResults, searching} = this.props
+    if (query && (query != '')){
+      if (!searching) {
+        return this.filterEvidenceCandidates(searchResults)
+      }
+    } else if (user) {
+      return this.filterEvidenceCandidates(user.recentlyViewed)
+    }
+  }
+
+  render(){
+    const {search, searching} = this.props.data || {}
+    return (
+      this.props.render({suggestions: this.suggestions(), searching: searching})
+    )
+  }
+}
+
+export default compose(
+  graphql(schema.Search, {
+    skip: (ownProps) => !ownProps.query || (ownProps.query == ''),
+    props: ({ownProps, data: {loading, search, refetch}}) => ({
+      searching: loading,
+      searchResults: search,
+      refetchSearch: refetch
+    })
+  }),
+  graphql(schema.CurrentUserQuery, {
+    props: ({ownProps, data: {loading, currentUser, refetch}}) => ({
+      userLoading: loading,
+      user: currentUser,
+      refetchUser: refetch
+    })
+  })
+)(ClaimSuggestor)

--- a/static/js/ys/components/TitleText.jsx
+++ b/static/js/ys/components/TitleText.jsx
@@ -1,33 +1,108 @@
 import React from 'react'
-import PropTypes from 'prop-types'
+import { graphql } from 'react-apollo';
 import { Form, Text, TextArea, Field } from 'react-form'
-import CharCount from './CharCount'
+import PropTypes from 'prop-types'
+
 import * as validations from '../validations'
+import * as schema from '../schema';
 
-const TitleText = props => (
-  <Field field={props.field}>
-    {fieldApi => {
-      // field is here to strip that property out of `rest`
-      const { field, ...rest } = props
-      const { value, error, warning, success, setValue, setTouched } = fieldApi
-      let classesCharCounterDefault = "charCounter "
-      let classesErrorArea = `titleTextErrorArea ${(error && error.title) ? "titleTextErrorAreaContent" : "" }`
-      return (
-        <div className="claimTitleField">
-          <CharCount countedValue={value.title || ""} maxChars={validations.titleMaxCharacterCount} render={({charsLeft}) => (
-            <span>
-              <span className={classesErrorArea}>{error && error.title}</span>
-              <TextArea field="title" {...rest}/>
-              <span className={classesCharCounterDefault + (charsLeft && charsLeft < 0 ? ' overMaxChars' : '')}>{charsLeft}</span>              
-            </span>
-          )}/>
-        </div>
-      )
-    }}
-  </Field>
-);
+import CharCount from './CharCount'
+import ClaimSearch from './ClaimSearch'
 
-TitleText.propTypes = {
+// use onmousedown here to try to get in before blur hides the UI (see note in TitleText onBlur below)
+// TODO: think about ways to make the "suggestion UI hide" condition be "clicking on anything that is not the text input or suggestion ui itself"
+const ExistingClaimPicker = ({claims, onSelectClaim}) => <ul className="ExistingClaimList">
+      {claims && claims.map((claim) => <li onMouseDown={e => onSelectClaim(claim, e)} key={claim.id}>
+                            {claim.title}
+                            </li>)}
+</ul>
+
+class TitleText extends React.Component {
+
+  constructor(props) {
+    super(props)
+    this.invalidEvidenceURLs = new Set([props.point.url, ...this.evidence().map(claim => claim.url)])
+  }
+
+  static propTypes = {
+    point: PropTypes.object,
+    evidenceType: PropTypes.string,
+    currentEvidence: PropTypes.array,
+    addExistingClaim: PropTypes.func
+  }
+
+  state = {titleTextFocused: false}
+
+  selectExistingClaim = (claim) =>
+    this.props.addExistingClaim(this.props.evidenceType, claim)
+
+  evidence = () => {
+    let connections = this.props.point[this.props.evidenceType == "supporting" ? "supportingPoints" : "counterPoints"]
+    return connections ? connections.edges.map(edge => edge.node) : []
+  }
+
+ filterEvidenceCandidates = (claims) =>
+    claims.filter(claim => !this.invalidEvidenceURLs.has(claim.url))
+
+  existingClaimPicker = (titleValue, searchResults, searching) => {
+    if (titleValue && (titleValue != '')){
+      if (searching) {
+        return <div className="">Searching...</div>
+      } else {
+        return <ExistingClaimPicker claims={this.filterEvidenceCandidates(searchResults)} onSelectClaim={this.selectExistingClaim}/>
+      }
+    } else if (this.props.user) {
+      return <ExistingClaimPicker claims={this.filterEvidenceCandidates(this.props.user.recentlyViewed)} onSelectClaim={this.selectExistingClaim}/>
+    }
+  }
+
+  existingClaimPickerDropdown = (titleValue, searchResults, searching) => {
+    if (this.state.titleTextFocused) {
+      return <div className="existingClaimPickerDropdown">
+        <div className="existingClaimPickerHeading">Existing Claims:</div>
+        {this.existingClaimPicker(titleValue, searchResults, searching)}
+      </div>
+    }
+  }
+
+  render(){
+    const { field, ...restOfProps } = this.props
+    return <Field field={field}>
+      {fieldApi => {
+        const { value: { title }, error, warning, success, setValue, setTouched } = fieldApi
+        let classesCharCounterDefault = "charCounter "
+        let classesErrorArea = `titleTextErrorArea ${(error && error.title) ? "titleTextErrorAreaContent" : "" }`
+        return (
+          <div className="claimTitleField">
+            <ClaimSearch
+              query={title}
+              render={({results, searching}) => (
+                <CharCount countedValue={title || ""} maxChars={validations.titleMaxCharacterCount} render={({charsLeft}) => (
+                  <span>
+                    <span className={classesErrorArea}>{error && error.title}</span>
+                    <Text field="title" {...restOfProps}
+                          onFocus={() => {this.setState({titleTextFocused: true})}}
+                          // use the setTimeout here to allow the mousedown event in existingclaimpicker to fire consistently
+                          // right now this fires before the onClick in ExistingClaimPIcker and hides that UI before the click event can be fired
+                          // TODO: think about ways to make the "suggestion UI hide" condition be "clicking on anything that is not the text input or suggestion ui itself"
+                          onBlur={() => {setTimeout(() => this.setState({titleTextFocused: false}), 100)}}
+                      />
+                    {this.existingClaimPickerDropdown(title, results, searching)}
+                    <span className={classesCharCounterDefault + (charsLeft && charsLeft < 0 ? ' overMaxChars' : '')}>{charsLeft}</span>
+                  </span>
+                )}/>
+              )}/>
+          </div>
+        )
+      }}
+    </Field>
+  }
 }
 
-export default TitleText
+export default graphql(schema.CurrentUserQuery, {
+  props: ({ownProps, data: {loading, currentUser, refetch}}) => ({
+    userLoading: loading,
+    user: currentUser,
+    refetchUser: refetch
+  })
+})(TitleText)


### PR DESCRIPTION
we'd like to move toward a unified metaphor for user interaction around the title component. these refactorings enable that.

The feedback area doesn't work quite right yet, but I want @justlikeUNIBLAB to take a crack at it.