### PR TITLE
Don't show expanded points until data has loaded

### DIFF
--- a/static/js/ys/components/Point.jsx
+++ b/static/js/ys/components/Point.jsx
@@ -195,7 +195,11 @@ class EvidenceLink extends React.Component {
   evidenceButton = () => {
     if (this.hasEvidence()) {
       if (this.props.expanded) {
-        return <a className="cardBottomAction hideEvidence" onClick={this.handleClickHide}>Hide Evidence</a>
+        if (this.props.expansionLoading) {
+          return <span>Loading...</span>
+        } else {
+          return <a className="cardBottomAction hideEvidence" onClick={this.handleClickHide}>Hide Evidence</a>
+        }
       } else {
         return <a className="cardBottomAction seeEvidence" onClick={this.handleClickSee} onMouseOver={this.props.mouseOverPreload}>See Evidence</a>
       }
@@ -285,7 +289,6 @@ class PointCardComponent extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      expanded: props.expanded,
       relevanceRater: false
     }
     this.handleCancelEdit = this.handleCancelEdit.bind(this);
@@ -457,7 +460,7 @@ class PointCardComponent extends React.Component {
   }
 
   expanded() {
-    return this.props.expanded;
+    return this.props.expanded && !this.props.expansionLoading;
   }
 
   contentWidth() {
@@ -729,7 +732,7 @@ class PointCardComponent extends React.Component {
         {this.sources()}
         <div className="row-fluid">
         <div className="cardBottomActionRow" >
-        <span><EvidenceLink point={point} expanded={this.expanded()}
+        <span><EvidenceLink point={point} expanded={this.props.expanded} expansionLoading={this.props.expansionLoading}
                             onSee={this.handleSeeEvidence} onHide={this.handleHideEvidence}
                             mouseOverPreload={this.preloadPoint}/>
         </span>
@@ -772,7 +775,12 @@ class PointCardComponent extends React.Component {
 export const PointCard = compose(
   withApollo,
   graphql(GetPoint, {
-    skip: ({expanded}) => !expanded
+    skip: ({expanded}) => !expanded,
+    props: ({ownProps, data: { loading, ...rest }}) => ({
+      expansionLoading: loading,
+      ...rest
+    })
+
   }),
   graphql(CurrentUserQuery, {
     name: 'CurrentUserQuery',

--- a/static/js/ys/components/Point.jsx
+++ b/static/js/ys/components/Point.jsx
@@ -81,11 +81,11 @@ const VoteStats = ({point}) => (
 
 
 // used in PointCard and in PointList for the irrelevant claims links
-export const LinkedItemBullet = () => ( 
+export const LinkedItemBullet = () => (
   <div className={"dottedLine dottedLineElbow"}></div>
 )
 
-       
+
 
 class PointComponent extends React.Component {
   constructor(props) {
@@ -499,10 +499,9 @@ class PointCardComponent extends React.Component {
         return <div className={classesEvidenceBlock + " evidenceBlockEmpty"}>
           <AddEvidence point={this.point} type={"DUAL"}/>
         </div>
-      }
-      else {
+      } else {
         return <div className={classesEvidenceBlock}>
-         {this.props.parentPoint && <div className="dottedLine dottedLineExpansionIndicator"></div>} 
+         {this.props.parentPoint && <div className="dottedLine dottedLineExpansionIndicator"></div>}
          {this.renderDottedLinesEvidenceHeaderOrMargin()}
          <MediaQuery minWidth={singleColumnThreshold}>
           {this.hasSupportingEvidence() && this.supportingPoints()}
@@ -515,19 +514,19 @@ class PointCardComponent extends React.Component {
       }
     }
   }
- 
+
   renderDottedLinesEvidenceHeaderOrMargin() {
     return <div className="dottedLinesSplitEvidenceHeader">
       <MediaQuery minWidth={singleColumnThreshold}>
-        {this.hasSupportingEvidence() && this.hasCounterEvidence() && 
+        {this.hasSupportingEvidence() && this.hasCounterEvidence() &&
           <div>
             <div className="dottedLinesSplitEvidenceSupport"></div>
             <div className="dottedLinesSplitEvidenceCounter"></div>
           </div>
         }
       </MediaQuery>
-    </div>    
-  } 
+    </div>
+  }
 
   supportingPoints(){
     if (this.expanded() && this.point.supportingPoints) {


### PR DESCRIPTION
This ensures the deal animation always looks right.