### PR TITLE
Fixed JS warning from component unmounting

### DIFF
--- a/static/js/ys/components/RelevanceRater.jsx
+++ b/static/js/ys/components/RelevanceRater.jsx
@@ -8,6 +8,11 @@ import * as schema from '../schema';
 class RelevanceComponent extends React.Component {
 
   state = {rating: false}
+  componentUnmounting = false
+
+  componentWillUnmount() {
+    this.componentUnmounting = true
+  }
 
   static propTypes = {
     point: PropTypes.object.isRequired,
@@ -34,7 +39,8 @@ class RelevanceComponent extends React.Component {
       this.setState({rating: true})
       this.props.rate(point, parentPoint, link.type, vote).
         then( res => {
-          this.setState({rating: false})
+          if (!this.componentUnmounting)
+            this.setState({rating: false})
         });
     } else {
       $("#loginDialog").modal("show");


### PR DESCRIPTION
I don't think we'd want to cancel the promise returned by this.props.rate, b/c then the rating would never get saved. The only thing we want to prevent, when the component is being unmounted (due to a relevance below 35%), is the setting of a state property.

Note that shouldComponentUpdate(), which you can set to return false if you want to prevent state updates, was never getting called in this case, so it wasn't useful.