### PR TITLE
publish button now being disabled when we're over the charCount, but …

### DIFF
--- a/static/js/ys/components/QuickCreateClaim.jsx
+++ b/static/js/ys/components/QuickCreateClaim.jsx
@@ -58,7 +58,7 @@ export default class QuickCreateClaim extends React.Component {
               <TitleText id="newPointTextField" className="titleTextField" placeholder='Make a claim, eg "Dogs are better than cats."' />
             </div>
             <div className="claimCreationFormButtonBlock">
-              {this.submitButton({disabled: (!title || (title == "")) || (validationFailures > 0)})}
+              {this.submitButton({disabled: (!title || (title == "") || (title.length > validations.titleMaxCharacterCount) ) || (validationFailures > 0)})}
             </div>
           </form>
       )}


### PR DESCRIPTION
In the QuickCreateForm, the publish button was not being disabled when a claim was over 200 characters. This commit creates that behavior, but I'm not certain I'm doing it the right way. I've added the condition (title.length > validations.titleMaxCharacterCount) to QuickCreateClaim, but it seems odd this condition would be needed in both QuickCreate and validations. That said... it seems to work. So if we want to kick the can on "doing it right" I can just add a comment to that effect around this code.  