### PR TITLE
made enter and return key work again on TitleText form

### DIFF
--- a/static/js/ys/components/AddEvidenceForm.jsx
+++ b/static/js/ys/components/AddEvidenceForm.jsx
@@ -43,7 +43,8 @@ class AddEvidenceForm extends React.Component {
                      suggestExistingClaims={true}
                      point={point}
                      evidenceType={evidenceType}
-                     addExistingClaim={addExistingClaim}/>
+                     addExistingClaim={addExistingClaim}
+                     onSubmit={submitForm}/>
           </div>
           <div className="claimCreationFormButtonBlock">
             <button type="submit" className={submitClasses} disabled={(!title || (title == "")) || (validationFailures > 0)}>Add</button>

--- a/static/js/ys/components/EditPoint.jsx
+++ b/static/js/ys/components/EditPoint.jsx
@@ -13,7 +13,7 @@ const EditTitleForm = ({point, onSubmit, onClick}) => {
       { formApi => (
         <form onSubmit={formApi.submitForm} id="form1" className="editPointTextForm">
           <div className="claimCreationFormFieldBlock">
-            <TitleText onClick={onClick} id="editPointTextField" className="titleTextField"/>
+            <TitleText onClick={onClick} id="editPointTextField" className="titleTextField" onSubmit={formApi.submitForm}/>
           </div>
           <div className="claimCreationFormButtonBlock">
             <button onClick={onClick} className="buttonUX2 createClaimFormButton" type="submit">Save</button>

--- a/static/js/ys/components/QuickCreateClaim.jsx
+++ b/static/js/ys/components/QuickCreateClaim.jsx
@@ -44,7 +44,7 @@ export default class QuickCreateClaim extends React.Component {
     if (this.state.submitting) {
       return <span>Adding your point...</span>;
     } else {
-      return <button onClick={this.props.onClick}className="buttonUX2 buttonUX2Blue buttonUX2RespIcon createClaimFormButton" type="submit" {...rest}>{this.submitButtonLabel()}</button>;
+      return <button className="buttonUX2 buttonUX2Blue buttonUX2RespIcon createClaimFormButton" type="submit" {...rest}>{this.submitButtonLabel()}</button>;
     }
   }
 
@@ -55,7 +55,7 @@ export default class QuickCreateClaim extends React.Component {
       { ({validationFailures, values: {title}, submitForm}) => (
           <form onSubmit={submitForm} id="mainPageClaimCreationForm">
             <div className="claimCreationFormFieldBlock">
-              <TitleText id="newPointTextField" className="titleTextField" placeholder='Make a claim, eg "Dogs are better than cats."' />
+              <TitleText id="newPointTextField" className="titleTextField" onSubmit={submitForm} placeholder='Make a claim, eg "Dogs are better than cats."' />
             </div>
             <div className="claimCreationFormButtonBlock">
               {this.submitButton({disabled: (!title || (title == "")) || (validationFailures > 0)})}

--- a/static/js/ys/components/TitleText.jsx
+++ b/static/js/ys/components/TitleText.jsx
@@ -50,11 +50,18 @@ class TitleText extends React.Component {
   showFeedbackArea = (error, suggestions) =>
     this.state.titleTextFocused && (error || (this.props.suggestExistingClaims && suggestions && suggestions.length > 0 ))
 
+  onEnterPress = (e) => {
+    if(e.keyCode == 13) {
+      e.preventDefault();
+      this.props.onSubmit();
+    }
+  }  
+    
   // To make feedbackArea persistent change {titleTextFocused: false} to {titleTextFocused: true}  
   renderCountedTextField = (title, textProps, error, suggestions, searching) =>
     <CharCount countedValue={title || ""} maxChars={validations.titleMaxCharacterCount} render={({charsLeft}) => (
       <span>
-        <TextArea field="title" {...textProps}
+        <TextArea field="title" {...textProps} onKeyDown={this.onEnterPress}
               onFocus={() => {this.setState({titleTextFocused: true})}}
               // use the setTimeout here to allow the mousedown event in existingclaimpicker to fire consistently
               // right now this fires before the onClick in ExistingClaimPIcker and hides that UI before the click event can be fired


### PR DESCRIPTION
Made enter and return key work again on TitleText form. I suspect they stopped working when we moved from a single-line <input> to a multi-line <textarea>.  Note that in the QuickCreateClaim submit button I have also removed an onClick={this.props.onClick} that I suspect is vestigial - I think that work is now handled by type="submit".