### PR TITLE
Use prefix-based keys in the expansion index

### DIFF
--- a/static/js/ys/components/ExpandedIndex.jsx
+++ b/static/js/ys/components/ExpandedIndex.jsx
@@ -64,17 +64,17 @@ class ExpandedIndexProviderComponent extends React.Component {
     this.updateURLExpandedIndex(params, index)
   }
 
-  expansionIndexKey = (point, depth) => point.url + depth
+  expansionIndexKey = (point, prefix) => (prefix || "") + point.url
 
-  expand = (point, depth) => {
-    this.modifyStateAndURL(point, index => index[this.expansionIndexKey(point, depth)] = true)
+  expand = (point, prefix) => {
+    this.modifyStateAndURL(point, index => index[this.expansionIndexKey(point, prefix)] = true)
   }
 
-  collapse = (point, depth) => {
-    this.modifyStateAndURL(point, index => delete index[this.expansionIndexKey(point, depth)])
+  collapse = (point, prefix) => {
+    this.modifyStateAndURL(point, index => delete index[this.expansionIndexKey(point, prefix)])
   }
 
-  isExpanded = (point, depth) => !!this.state.index[this.expansionIndexKey(point, depth)]
+  isExpanded = (point, prefix) => !!this.state.index[this.expansionIndexKey(point, prefix)]
 
   render(){
     // IMPORTANT: value must always point at state so that the context has a consistent reference
@@ -90,13 +90,13 @@ export const ExpandedIndexProvider =  withRouter(ExpandedIndexProviderComponent)
 
 export function withExpandedIndex(Component) {
   return function ExpandedIndexComponent(props){
-    const {point, depth} = props
+    const {point, prefix} = props
     return (
       <Context.Consumer>
         {expansion => <Component {...props}
-                                 expanded={expansion.isExpanded(point, depth)}
-                                 onExpand={() => expansion.expand(point, depth)}
-                                 onCollapse={() => expansion.collapse(point, depth)}
+                                 expanded={expansion.isExpanded(point, prefix)}
+                                 onExpand={() => expansion.expand(point, prefix)}
+                                 onCollapse={() => expansion.collapse(point, prefix)}
                                  expansion={expansion} />}
       </Context.Consumer>
     )

--- a/static/js/ys/components/Point.jsx
+++ b/static/js/ys/components/Point.jsx
@@ -630,7 +630,7 @@ class PointCardComponent extends React.Component {
   )
 
   isChildExpanded = (child) =>
-    !!this.props.expansion.isExpanded(child, this.childDepth())
+    !!this.props.expansion.isExpanded(child, this.childPrefix())
 
   childrenExpanded = (edgeName) => {
     const point = this.props.point
@@ -682,16 +682,16 @@ class PointCardComponent extends React.Component {
     </div>
   }
 
-  depth = () => this.props.depth || 0
+  prefix = () => this.props.prefix || ''
 
-  childDepth = () => this.depth() + 1
+  childPrefix = () => this.prefix() + this.props.point.url
 
   supportingPoints(){
     if (this.expanded() && this.point.supportingPoints) {
       return <div className="evidenceBlockSupport evidenceBlockFirstColAlignment">
         <div className="evidenceList">
           <div className="heading supportHeading">Evidence For</div>
-          <PointList edges={this.point.supportingPoints.edges} parentPoint={this.point} relevanceThreshold={config.relevanceThreshold} depth={this.childDepth()}/>
+          <PointList edges={this.point.supportingPoints.edges} parentPoint={this.point} relevanceThreshold={config.relevanceThreshold} prefix={this.childPrefix()}/>
           {!this.supportingChildrenExpanded() && (this.point.counterPoints.edges.length < 1 ? <AddEvidence point={this.point} type={"DUAL"}/> : <AddEvidence point={this.point} type={"SUPPORT"}/>)}
         </div>
       </div>
@@ -705,7 +705,7 @@ class PointCardComponent extends React.Component {
         {this.point.supportingPoints.edges.length > 0 ? <div className="dottedLineCounterConnector"></div> : "" }
         <div className="evidenceList">
           <div className="heading counterHeading">Evidence Against</div>
-          <PointList edges={this.point.counterPoints.edges} parentPoint={this.point} relevanceThreshold={config.relevanceThreshold} depth={this.childDepth()}/>
+          <PointList edges={this.point.counterPoints.edges} parentPoint={this.point} relevanceThreshold={config.relevanceThreshold} prefix={this.childPrefix()}/>
           {!this.counterChildrenExpanded() && (this.point.supportingPoints.edges.length < 1 ? <AddEvidence point={this.point} type={"DUAL"}/> : <AddEvidence point={this.point} type={"COUNTER"}/>) }
         </div>
       </div>
@@ -718,7 +718,7 @@ class PointCardComponent extends React.Component {
       return <div className="evidenceBlockBoth evidenceBlockFirstColAlignment">
         <div className="evidenceList">
           {this.point.relevantPoints.edges.length > 0 && <div className="heading supportHeading">Evidence</div>}
-        <PointList edges={this.point.relevantPoints.edges} parentPoint={this.point} relevanceThreshold={config.relevanceThreshold} depth={this.childDepth()}/>
+        <PointList edges={this.point.relevantPoints.edges} parentPoint={this.point} relevanceThreshold={config.relevanceThreshold} prefix={this.childPrefix()}/>
         {!this.relevantChildrenExpanded() && <AddEvidence point={this.point} type={"DUAL"}/>}
         </div>
       </div>

--- a/static/js/ys/components/PointList.jsx
+++ b/static/js/ys/components/PointList.jsx
@@ -25,17 +25,17 @@ class PointListComponent extends React.Component {
     return this.props.parentPoint;
   }
 
-  depth = () => this.props.depth || 0
+  prefix = () => this.props.prefix || ''
 
   renderPoint = (point, badge) => {
     return <PointCard key={point.url} url={point.url} point={point}
-                      parentPoint={this.parentPoint} depth={this.depth()}
+                      parentPoint={this.parentPoint} prefix={this.prefix()}
                       onDelete={this.props.onDelete} badge={badge} />
   }
 
   renderEdge = (edge) => {
     return <PointCard key={edge.node.url} point={edge.node} url={edge.node.url}
-                      link={edge.link} parentPoint={this.parentPoint} depth={this.depth()}
+                      link={edge.link} parentPoint={this.parentPoint} prefix={this.prefix()}
                       onDelete={this.props.onDelete}/>
   }
 

--- a/static/js/ys/home.js
+++ b/static/js/ys/home.js
@@ -138,7 +138,7 @@ class Home extends React.Component {
       </div>
       <div className="mainPageContentArea">
         <div id="mainPageFeaturedArea" className="mainPageContentArea">
-          { featuredPoint ? <PointList point={featuredPoint} badge="Featured"/> : <div className="spinnerPointList">Loading Featured Claim...</div> }
+          { featuredPoint ? <PointList point={featuredPoint} badge="Featured" prefix="featured"/> : <div className="spinnerPointList">Loading Featured Claim...</div> }
         </div>
         <div id="mainPageMainArea">
           <Tabs selectedTabClassName="tabUX2_selected" selectedIndex={this.state.tabIndex} onSelect={tabIndex => this.setState({ tabIndex })}>
@@ -147,7 +147,7 @@ class Home extends React.Component {
               <Tab className="tabUX2">Editor's Picks</Tab>
             </TabList>
             <TabPanel>
-              <NewPoints pointsPerPage={config.newPointsPageSize}/>
+              <NewPoints pointsPerPage={config.newPointsPageSize} prefix="new"/>
             </TabPanel>
             <TabPanel>
               <EditorsPicks/>


### PR DESCRIPTION
this allows us to give the "New" and "Featured" lists different
prefixes so we don't get spooky action at a distance